### PR TITLE
"long" is not documented; change to documented "wide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This proposal reached Stage 1 at the 2020 Feb TC39 meeting.
 # Quick Start Example
 
 ```javascript
-new Intl.DurationFormat("fr-FR", { style: "long" }).format({
+new Intl.DurationFormat("fr-FR", { style: "wide" }).format({
     hours: 1,
     minutes: 46,
     seconds: 40,


### PR DESCRIPTION
I don't know which way you want to go, but "long" does not seem to be listed, while "wide" is elsewhere listed. Thanks!